### PR TITLE
Fixed spelling of 'release-group' in search query to include the hyphen

### DIFF
--- a/lib/WebService/MusicBrainz/ReleaseGroup.pm
+++ b/lib/WebService/MusicBrainz/ReleaseGroup.pm
@@ -102,7 +102,7 @@ sub search {
    my $self = shift;
    my $params = shift;
 
-   my $response = $self->query()->get('releasegroup', $params);    
+   my $response = $self->query()->get('release-group', $params);    
 
    return $response;
 }


### PR DESCRIPTION
This is to resolve [Bug #63916](https://rt.cpan.org/Public/Bug/Display.html?id=63916). After checking the docs on the API, it does appear that the correct endpoint is 'release-group', not 'releasegroup'.

Compare

with: https://musicbrainz.org/ws/2/release-group?query=foo (xml response)
and without: https://musicbrainz.org/ws/2/releasegroup?query=foo (404)
