### PR TITLE
Added support for querying a discid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pm_to_blib
 *.bak
 *.old
 *.skip
+Makefile

--- a/Changes
+++ b/Changes
@@ -131,3 +131,6 @@ Revision history for Perl extension WebService::MusicBrainz.
 1.0.1 Sunday March 26th 2017
 	- More tests
 	- Fix minimum Mojolicious version
+
+1.0.3 Sunday December 17th 2017
+	- Added support to query for a discid

--- a/lib/WebService/MusicBrainz.pm
+++ b/lib/WebService/MusicBrainz.pm
@@ -8,7 +8,7 @@ use Data::Dumper;
 our $VERSION = '1.0.1';
 
 has 'request';
-has valid_resources => sub { ['area','artist','label','recording','release','release_group'] };
+has valid_resources => sub { ['area','artist','discid','label','recording','release','release_group'] };
 has relationships => sub {
     my $rels = ['area-rels','artist-rels','event-rels','instrument-rels','label-rels','place-rels','recording-rels','release-rels','release-group-rels','series-rels','url-rels','work-rels'];
     return $rels;
@@ -19,6 +19,7 @@ has subquery_map => sub {
     my %subquery_map;
 
     $subquery_map{artist}        = ['recordings','releases','release-groups','works'];
+    $subquery_map{discid}        = ['artists','artist-credits','collections','labels','recordings','release-groups' ];
     $subquery_map{label}         = ['releases'];
     $subquery_map{recording}     = ['artists','releases'];
     $subquery_map{release}       = ['artists','collections','labels','recordings','release-groups' ];
@@ -32,6 +33,7 @@ has search_fields_by_resource => sub {
 
     $search_fields{area}          = ['aid','alias','area','begin','comment','end','ended','sortname','iso','iso1','iso2','iso3','type'];
     $search_fields{artist}        = ['area','beginarea','endarea','arid','artist','artistaccent','alias','begin','comment','country','end','ended','gender','ipi','sortname','tag','type'];
+    $search_fields{discid}        = ['discid'];
     $search_fields{label}         = ['alias','area','begin','code','comment','country','end','ended','ipi','label','labelaccent','laid','sortname','type','tag'];
     $search_fields{recording}     = ['arid','artist','artistname','creditname','comment','country','date','dur','format','isrc','number','position','primarytype','puid','qdur','recording','recordingaccent','reid','release','rgid','rid','secondarytype','status','tid','trnum','tracks','tracksrelease','tag','type','video'];
     $search_fields{release_group} = ['arid','artist','comment','creditname','primarytype','rgid','releasegroup','releasegroupaccent','releases','release','reid','secondarytype','status','tag','type'];
@@ -84,8 +86,15 @@ sub search {
     if(exists $search_query->{mbid}) {
         $self->request()->mbid($search_query->{mbid});
         delete $search_query->{mbid};
+    }
 
-        # only use "inc" parameters when a specific MBID is given
+    if(exists $search_query->{discid}) {
+        $self->request()->discid($search_query->{discid});
+        delete $search_query->{discid};
+    }
+
+    # only use "inc" parameters when a specific MBID or DISCID is given
+    if ($self->request()->mbid() or $self->request()->discid()) {
         if(exists $search_query->{inc}) {
             my @inc_subqueries;
 

--- a/lib/WebService/MusicBrainz/Request.pm
+++ b/lib/WebService/MusicBrainz/Request.pm
@@ -10,6 +10,7 @@ has ua => sub { Mojo::UserAgent->new() };
 has 'format' => 'json';
 has 'search_resource';
 has 'mbid';
+has 'discid';
 has 'inc' => sub { [] };
 has 'query_params';
 has offset => 0;
@@ -27,6 +28,7 @@ sub make_url {
     push @url_parts, $self->url_base();
     push @url_parts, $self->search_resource();
     push @url_parts, $self->mbid() if $self->mbid;
+    push @url_parts, $self->discid() if $self->discid;
 
     my $url_str = join '/', @url_parts;
 

--- a/t/DiscID.t
+++ b/t/DiscID.t
@@ -1,0 +1,41 @@
+use strict;
+use Test::More;
+
+use WebService::MusicBrainz;
+use Data::Dumper;
+
+my $ws = WebService::MusicBrainz->new();
+ok($ws);
+
+my $s1_res = $ws->search(discid => { discid => 'NmFqfPXBZfk05ZpbTcL.IvmEtQY-' });
+ok($s1_res->{'offset-count'} eq 16);
+ok(@{$s1_res->{offsets}} eq 16);
+ok($s1_res->{offsets}->[0] eq 150);
+ok($s1_res->{offsets}->[1] eq 20822);
+ok($s1_res->{offsets}->[2] eq 39976);
+ok($s1_res->{offsets}->[3] eq 57651);
+ok($s1_res->{offsets}->[4] eq 82691);
+ok($s1_res->{offsets}->[5] eq 97773);
+ok($s1_res->{offsets}->[6] eq 116625);
+ok($s1_res->{offsets}->[7] eq 140670);
+ok($s1_res->{offsets}->[8] eq 160155);
+ok($s1_res->{offsets}->[9] eq 183516);
+ok($s1_res->{offsets}->[10] eq 194429);
+ok($s1_res->{offsets}->[11] eq 210901);
+ok($s1_res->{offsets}->[12] eq 228250);
+ok($s1_res->{offsets}->[13] eq 246216);
+ok($s1_res->{offsets}->[14] eq 272031);
+ok($s1_res->{offsets}->[15] eq 285133);
+ok($s1_res->{id} eq 'NmFqfPXBZfk05ZpbTcL.IvmEtQY-');
+ok($s1_res->{sectors} eq 308410);
+ok(@{$s1_res->{releases}} > 0);
+ok(not defined @{$s1_res->{releases}}[0]->{'artist-credit'});
+sleep(1);
+
+my $s2_res = $ws->search(discid => { discid => 'NmFqfPXBZfk05ZpbTcL.IvmEtQY-', inc => ' artists' });
+ok(@{$s2_res->{releases}} > 0);
+ok(defined @{$s2_res->{releases}}[0]->{'artist-credit'});
+ok(defined @{$s2_res->{releases}}[0]->{'artist-credit'}->[0]->{artist});
+ok(@{$s2_res->{releases}}[0]->{'artist-credit'}->[0]->{artist}->{'sort-name'} eq 'Adams, Ryan');
+
+done_testing();


### PR DESCRIPTION
discid queries are different lookup type (a bit like MBID) and require a
bit of special casing, but are pretty straightforward otherwise.

The `inc` parameter for discid queries supports the same values as
`release` according to the API doc.