### PR TITLE
Tests: Modifying area code as it fails

### DIFF
--- a/t/Area.t
+++ b/t/Area.t
@@ -42,7 +42,7 @@ sleep(1);
 my $s5_res = $ws->search(area => { iso => 'US-CA', fmt => 'xml' });
 exit_if_mb_busy($s5_res);
 ok($s5_res->find('name')->first->text eq 'California');
-ok($s5_res->at('area')->attr('ext:score') == 100);
+ok($s5_res->at('area')->attr('ns2:score') == 100);
 sleep(1);
 
 done_testing();


### PR DESCRIPTION
Hi Bob,

I'm currently working on an update of the OpenBSD port of webservice-musicbrainz.

Area.t fails at line 45 because the API returns something different
than expected, see http://musicbrainz.org/ws/2/area/?query=%22California%22 

ext:score is not there, it's ns2:score now, despite what the official API docs says. I'm proposing a simple change to the test. It passes here indeed.

Let me know if you have something different in mind!

Charlène :) 
