### PR TITLE
HTTPS by default

### DIFF
--- a/lib/WebService/MusicBrainz.pm
+++ b/lib/WebService/MusicBrainz.pm
@@ -289,7 +289,7 @@ it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 
-http://musicbrainz.org/doc/Development/XML_Web_Service/Version_2
+https://musicbrainz.org/doc/MusicBrainz_API
 
 =cut
 

--- a/lib/WebService/MusicBrainz/Request.pm
+++ b/lib/WebService/MusicBrainz/Request.pm
@@ -5,7 +5,7 @@ use Mojo::UserAgent;
 use Mojo::URL;
 use Mojo::Util qw/dumper/;
 
-has url_base => 'http://musicbrainz.org/ws/2';
+has url_base => 'https://musicbrainz.org/ws/2';
 has ua => sub { Mojo::UserAgent->new() };
 has 'format' => 'json';
 has 'search_resource';
@@ -114,7 +114,7 @@ it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 
-http://wiki.musicbrainz.org/XMLWebService
+https://wiki.musicbrainz.org/XMLWebService
 
 =cut
 


### PR DESCRIPTION
These URLs all get redirected from HTTP to HTTPS by MusicBrainz, so we might as well save ourselves a round trip by using HTTPS in the first place.