### PR TITLE
Apifriendly - enforce api rate limitations 

### DIFF
--- a/lib/WebService/MusicBrainz.pm
+++ b/lib/WebService/MusicBrainz.pm
@@ -46,7 +46,7 @@ has search_fields_by_resource => sub {
     $search_fields{artist} = [
         'area',   'beginarea', 'endarea',  'arid',    'artist', 'artistaccent',
         'alias',  'begin',     'comment',  'country', 'end',    'ended',
-        'gender', 'ipi',       'sortname', 'tag',     'type'
+        'gender', 'ipi',       'sortname', 'status', 'tag',     'type'
     ];
     $search_fields{discid} = ['discid'];
     $search_fields{label}  = [

--- a/lib/WebService/MusicBrainz.pm
+++ b/lib/WebService/MusicBrainz.pm
@@ -250,8 +250,10 @@ string on all requests to:
 
   WebService::MusicBrainz/<version> { <your email }
 
-like they say the want. If you want to be less compliant, the 'uaid' is a freeform
-string you may set as the UserAgent string. 
+like they say the want. 
+
+If you want to name your application using this module, the 'uaid' is a freeform
+string which, if set, becomes the UserAgent string. 
 
 If neither of these are defined, the old behavior (Mojo::UserAgent's default) will
 be used. 

--- a/lib/WebService/MusicBrainz/Request.pm
+++ b/lib/WebService/MusicBrainz/Request.pm
@@ -16,6 +16,12 @@ has 'query_params';
 has offset => 0;
 has debug => sub { $ENV{MUSICBRAINZ_DEBUG} || 0 };;
 
+# New features will not be used unless they are explicitly defined
+has 'cache';
+has 'throttle';
+has 'uaid';
+has 'v';
+
 our $VERSION = '1.0';
 
 binmode STDOUT, ":encoding(UTF-8)";
@@ -63,6 +69,10 @@ sub make_url {
 
 sub result {
     my $self = shift;
+
+    if (defined($self->uaid) && length($self->uaid) > 0) {
+       $self->ua->transactor->name("WebService::MusicBrainz/" . $self->v . ' { ' . $self->uaid . '}');
+    }
 
     my $request_url = $self->make_url();
 

--- a/lib/WebService/MusicBrainz/Request.pm
+++ b/lib/WebService/MusicBrainz/Request.pm
@@ -34,6 +34,10 @@ our $VERSION = '1.0';
 
 binmode STDOUT, ":encoding(UTF-8)";
 
+my @not_in_query = (qw(
+  status type
+));
+
 sub make_url {
     my $self = shift;
 
@@ -48,7 +52,7 @@ sub make_url {
 
     $url_str .= '?fmt=' . $self->format;
 
-    if(scalar(@{ $self->inc }) > 0) {
+    if(scalar(@{ $self->inc }) > 0) { 
         my $inc_query = join '+', @{ $self->inc }; 
 
         $url_str .= '&inc=' . $inc_query;
@@ -57,7 +61,11 @@ sub make_url {
     my @extra_params;
 
     foreach my $key (keys %{ $self->query_params }) {
+      if (grep($_ eq $key, @not_in_query) > 0) {
+        $url_str .= '&' . $key . '=' . $self->query_params->{$key};
+      } else {
         push @extra_params, $key . ':"' . $self->query_params->{$key} . '"';
+      }
     }
 
     if(scalar(@extra_params) > 0) {

--- a/t/AreaNB.t
+++ b/t/AreaNB.t
@@ -1,0 +1,88 @@
+use strict;
+use Test::More;
+
+use Data::Dumper;
+use Mojo::IOLoop;
+use Syntax::Keyword::Try;
+
+use WebService::MusicBrainz;
+
+#
+## Ported from Area.t, but this is all boilerplate and should likely break out into it's own idea
+my $ws = WebService::MusicBrainz->new(
+  throttle => 1.65,
+);
+ok($ws);
+
+my $NODIE = 0;
+my $WILLDIE = 1;
+sub queue_request {
+  my $expectDeath = shift;
+  my $cb = shift;
+  my $errcb = shift;
+  my $prom;
+  try {
+    $prom = $ws->search_p(@_);
+    ok(ref($prom) eq 'Mojo::Promise', "Search_p returns a promise");
+  } catch {
+    my $expected = ($expectDeath) ? "(expected)" : "(UNexpected)";
+    ok($expectDeath, "Search_p died ($expected): $@");
+    return;
+  }
+    
+  $prom->then(sub {
+    $cb->(shift);
+    return;
+  })->catch(sub {
+    $errcb->($_[0]);
+    warn "Detected error; $_[0]\n" . Dumper(\@_);
+    return;
+  });
+}
+
+my $errcheck = sub {
+  ok(0, "Detected an error: $_[0]");
+};
+my $check = sub {
+  my $res = shift;
+  ok($res->{type} eq 'City');
+  ok($res->{name} eq 'Nashville');
+  ok($res->{'sort-name'} eq 'Nashville');
+};
+queue_request($NODIE, $check, $errcheck, area => { mbid => '044208de-d843-4523-bd49-0957044e05ae' });
+
+$check = sub {
+  my $res = shift;
+  ok($res->{count} == 2);
+  ok($res->{areas}->[0]->{type} eq 'City');
+  ok($res->{areas}->[1]->{type} eq 'City');
+};
+queue_request($NODIE, $check, $errcheck, area => { area => 'cincinnati' });
+
+$check = sub {
+  my $res = shift;
+  ok($res->{count} == 1);
+  ok($res->{areas}->[0]->{name} eq 'Ohio');
+};
+queue_request($NODIE, $check, $errcheck, area => { iso => 'US-OH' });
+
+$check = sub {
+  ok(0,"Should not get a success here");
+  warn Dumper(\@_);
+};
+queue_request($WILLDIE, $check, sub {
+  ok(0,"This should have detected an error, but not at this stage: ($_[0])");
+  warn Dumper(\@_);
+}, area => { something => '99999' });
+
+$check = sub {
+  my $res = shift;
+  ok($res->find('name')->first->text eq 'California');
+  ok($res->at('area')->attr('ns2:score') == 100);
+
+  Mojo::IOLoop->stop();
+};
+queue_request($NODIE, $check, $errcheck, area => { iso => 'US-CA', fmt => 'xml' });
+
+Mojo::IOLoop->singleton->start;
+done_testing();

--- a/t/AreaThrottle.t
+++ b/t/AreaThrottle.t
@@ -1,0 +1,45 @@
+use strict;
+use Test::More;
+
+use WebService::MusicBrainz;
+
+sub exit_if_mb_busy {
+   my $res = shift;
+   if(exists $res->{error} && $res->{error} =~ m/^The MusicBrainz web server is currently busy/) {
+      done_testing();
+      exit(0);
+   }
+}
+
+# With 'throttle', one should not need the sleep calls :)
+my $ws = WebService::MusicBrainz->new( throttle => 1.2 );
+ok($ws);
+
+# JSON TESTS
+my $s1_res = $ws->search(area => { mbid => '044208de-d843-4523-bd49-0957044e05ae' });
+exit_if_mb_busy($s1_res);
+ok($s1_res->{type} eq 'City');
+ok($s1_res->{name} eq 'Nashville');
+ok($s1_res->{'sort-name'} eq 'Nashville');
+
+my $s2_res = $ws->search(area => { area => 'cincinnati' });
+exit_if_mb_busy($s2_res);
+ok($s2_res->{count} == 2);
+ok($s2_res->{areas}->[0]->{type} eq 'City');
+ok($s2_res->{areas}->[1]->{type} eq 'City');
+
+my $s3_res = $ws->search(area => { iso => 'US-OH' });
+exit_if_mb_busy($s3_res);
+ok($s3_res->{count} == 1);
+ok($s3_res->{areas}->[0]->{name} eq 'Ohio');
+
+eval { my $s4_res = $ws->search(area => { something => '99999' }) };
+if($@) { ok($@) }  # catch error
+
+my $s5_res = $ws->search(area => { iso => 'US-CA', fmt => 'xml' });
+exit_if_mb_busy($s5_res);
+ok($s5_res->find('name')->first->text eq 'California');
+ok($s5_res->at('area')->attr('ns2:score') == 100);
+sleep(1);
+
+done_testing();

--- a/t/Cache.t
+++ b/t/Cache.t
@@ -1,0 +1,44 @@
+use strict;
+use Test::More;
+
+use Mojo::IOLoop;
+use WebService::MusicBrainz;
+
+sub fail_if_mb_busy {
+   my $res = shift;
+   if(exists $res->{error}) {
+     ok(0, "We got an error so we are presuming the cache is not working: " . $res->{error});
+     exit(0);
+   }
+}
+
+# In practice, the usage of cache like this will remove any upper level control of this
+# cache. Thankfully, this is just a test. :)
+my $ws = WebService::MusicBrainz->new( cache => {}, throttle => 1.1 );
+ok($ws);
+
+# Blocking mode
+foreach my $k (0..10) {
+  my $res = $ws->search(area => { mbid => '044208de-d843-4523-bd49-0957044e05ae' });
+  fail_if_mb_busy($res);
+  ok($res->{type} eq 'City');
+  ok($res->{name} eq 'Nashville');
+  ok($res->{'sort-name'} eq 'Nashville');
+}
+
+# Non-blocking mode, but this should never put a request out because it's in the
+# cache.
+foreach my $k (0..10) {
+  $ws->search_p(area => { mbid => '044208de-d843-4523-bd49-0957044e05ae' })->then(sub {
+    my $res = shift;
+    ok($res->{type} eq 'City');
+    ok($res->{name} eq 'Nashville');
+    ok($res->{'sort-name'} eq 'Nashville');
+    Mojo::IOLoop->stop() if ($k == 10);
+  })->catch(sub {
+    ok(0, "Some error occurred in non-blocking request: $_[0]");
+  });
+}
+
+Mojo::IOLoop->start;
+done_testing();

--- a/t/Cache.t
+++ b/t/Cache.t
@@ -12,8 +12,6 @@ sub fail_if_mb_busy {
    }
 }
 
-# In practice, the usage of cache like this will remove any upper level control of this
-# cache. Thankfully, this is just a test. :)
 my $ws = WebService::MusicBrainz->new( cache => {}, throttle => 1.1 );
 ok($ws);
 


### PR DESCRIPTION
I needed to write this for my own code, as I want to be friendly to the MusicBrainz servers. Thus I will be maintaining these for quite a while as it is how my code accesses MusicBrainz now and for the foreseeable future.  In the spirit of open source, I offer these changes to the original repo if they are wanted.

This pull request adds the following features

  - automatic api rate limiting in fractions of a second
  - an optional cache, assuming one-to-one correspondence between a URL and results in a small window of time. This is so you don't make the same lookup more than once.
  - a user agent string or you can just provide an email 
  - a non-blocking promise interface to search (and with rate limiting, this technique is ok to use now)

I'm open to comments or changes, or you can just completely ignore this pull request as ravings from a mad developer. ;)