### PR TITLE
Fix-up the release-group resource name

### DIFF
--- a/lib/WebService/MusicBrainz.pm
+++ b/lib/WebService/MusicBrainz.pm
@@ -8,7 +8,7 @@ our $VERSION = '1.0.4';
 
 has 'request';
 has valid_resources =>
-    sub { [ 'area', 'artist', 'discid', 'label', 'recording', 'release', 'release_group' ] };
+    sub { [ 'area', 'artist', 'discid', 'label', 'recording', 'release', 'release-group' ] };
 has relationships => sub {
     my $rels = [
         'area-rels',          'artist-rels', 'event-rels',     'instrument-rels',
@@ -27,7 +27,7 @@ our %subquery_map = (
     label         => [qw(releases)],
     recording     => [qw(artists releases)],
     release       => [qw(artists collections labels recordings release-groups)],
-    release_group => [qw(artists releases)],
+    'release-group' => [qw(artists releases)],
 );
 
 has search_fields_by_resource => sub {
@@ -58,7 +58,7 @@ has search_fields_by_resource => sub {
         'trnum',           'tracks',        'tracksrelease', 'tag',
         'type',            'video'
     ];
-    $search_fields{release_group} = [
+    $search_fields{'release-group'} = [
         'arid',        'artist',  'comment',      'creditname',
         'primarytype', 'rgid',    'releasegroup', 'releasegroupaccent',
         'releases',    'release', 'reid',         'secondarytype',


### PR DESCRIPTION
Handing the search() method `release_group` causes "Not a valid resource for search..."  Reading the API I see that `release-group` (with a dash) is used. :)