### PR TITLE
Fix t/Artist.t: Van Halen is not unique any more.

### DIFF
--- a/t/Artist.t
+++ b/t/Artist.t
@@ -55,7 +55,7 @@ sleep(1);
 
 my $s6_res = $ws->search(artist => { artist => 'Van Halen', type => 'group' });
 exit_if_mb_busy($s6_res);
-ok($s6_res->{count} == 1);
+ok($s6_res->{count} >= 1);
 ok($s6_res->{artists}->[0]->{type} eq 'Group');
 ok($s6_res->{artists}->[0]->{id} eq 'b665b768-0d83-4363-950c-31ed39317c15');
 sleep(1);


### PR DESCRIPTION

In Debian we are currently applying the following patch to
WebService-MusicBrainz.
We thought you might be interested in it too.

    Description: Fix t/Artist.t: Van Halen is not unique any more.
     t/Artist.t's 6th test fails, as the search for { artist => 'Van Halen', type => 'group' }
     does not return one result, but two:
     .
     #                            'name' => 'Van Halen',
     #                            'disambiguation' => 'American hard rock band',
     .
     #                            'name' => 'JUMP - America\'s Van Halen Experience',
     #                            'disambiguation' => 'Van Halen tribute band'
     Adjust the expected count. And use '>= 1' instead of '== 2' because who knows.
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2024-02-27
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libwebservice-musicbrainz-perl/raw/master/debian/patches/van-halen.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
